### PR TITLE
Core api ideas

### DIFF
--- a/Conference.js
+++ b/Conference.js
@@ -39,6 +39,15 @@ Conference.prototype.createMediaStreams = function (options, successCallback, er
 }
 
 /**
+ * Returns streams (matching a specific filter, if provided)
+ * @param [filter] an optional filter
+ * @example conference.getStreams(By.UserId(userId))
+ */
+Conference.prototype.getStreams = function (filter) {
+
+};
+
+
 /**
  * Attaches a handler for events(For example - "participant joined".) in the conference. All possible event are defined
  * in ConferenceEvents.

--- a/Conference.js
+++ b/Conference.js
@@ -39,40 +39,32 @@ Conference.prototype.createMediaStreams = function (options, successCallback, er
 }
 
 /**
+/**
  * Attaches a handler for events(For example - "participant joined".) in the conference. All possible event are defined
  * in ConferenceEvents.
  * @param eventId the event ID.
  * @param handler handler for the event.
+ *
+ * Note: consider adding eventing functionality by extending an EventEmitter impl, instead of rolling ourselves
  */
-Conference.prototype.addEventListener = function (eventId, handler) {
+Conference.prototype.on = function (eventId, handler) {
 
 }
 
 /**
  * Removes event listener
  * @param eventId the event ID.
+ * @param [handler] optional, the specific handler to unbind
+ *
+ * Note: consider adding eventing functionality by extending an EventEmitter impl, instead of rolling ourselves
  */
-Conference.prototype.removeEventListener = function (eventId) {
+Conference.prototype.off = function (eventId, handler) {
 
 }
 
-/**
- * Receives notifications from another participants for commands / custom events(send by sendPresenceCommand method).
- * @param command {String} the name of the command
- * @param handler {Function} handler for the command
- */
-Conference.prototype.addPresenceCommandListener = function (command, handler) {
-
-}
-
-
-/**
- * Removes command  listener
- * @param command {String}  the name of the command
- */
-Conference.prototype.removePresenceCommandListener = function (command) {
-
-}
+// Common aliases for event emitter
+Conference.prototype.addEventListener = Conference.prototype.on
+Conference.prototype.removeEventListener = Conference.prototype.off
 
 /**
  * Sends text message to the other participants in the conference
@@ -91,7 +83,7 @@ Conference.prototype.sendTextMessage = function (message) {
  * @param successCallback will be called when the command is successfully send.
  * @param errorCallback will be called when the command is not sent successfully.
  */
-Conference.prototype.sendPresenceCommand = function (name, values, persistent, successCallback, errorCallback) {
+Conference.prototype.sendSignal = function (signal) {
 
 }
 

--- a/Conference.js
+++ b/Conference.js
@@ -84,13 +84,13 @@ Conference.prototype.sendTextMessage = function (message) {
 }
 
 /**
- * Send presence command.
- * @param name the name of the command.
- * @param values Object with keys and values that will be send.
- * @param persistent if false the command will be sent only one time
+ * Send a signal.
+ * @param {object} signal the signal and it's values
+ * @param {string} signal.name the name of the signal.
+ * @param {boolean} signal.persistent if false the command will be sent only one time
  * otherwise it will be sent with every system message sent to the other participants.
- * @param successCallback will be called when the command is successfully send.
- * @param errorCallback will be called when the command is not sent successfully.
+ * @returns {Promise.<{void}, ConferenceError>} A promise that returns an array of created streams if resolved,
+ *     or an ConferenceError if rejected.
  */
 Conference.prototype.sendSignal = function (signal) {
 

--- a/Conference.js
+++ b/Conference.js
@@ -30,11 +30,10 @@ Conference.prototype.leave = function () {
  * Creates the media streams and returns them via the callback.
  * @param options Object with properties / settings defining which streams(Stream.AUDIO, Stream.VIDEO, Stream.DESKTOP)
  * should be created or some additional configurations about resolution for example.
- * @param successCallback callback that will receive the streams.
- * @param errorCallback callback that will be called if accessing the media streams fail.
- * @return an array of all created MediaStream-s
+ * @returns {Promise.<{Array.<Stream>}, ConferenceError>} A promise that returns an array of created streams if resolved,
+ *     or a ConferenceError if rejected.
  */
-Conference.prototype.createMediaStreams = function (options, successCallback, errorCallback) {
+Conference.prototype.share = function (options) {
 
 }
 
@@ -89,8 +88,7 @@ Conference.prototype.sendTextMessage = function (message) {
  * @param {string} signal.name the name of the signal.
  * @param {boolean} signal.persistent if false the command will be sent only one time
  * otherwise it will be sent with every system message sent to the other participants.
- * @returns {Promise.<{void}, ConferenceError>} A promise that returns an array of created streams if resolved,
- *     or an ConferenceError if rejected.
+ * @returns {Promise.<{void}, ConferenceError>} A promise that a ConferenceError if rejected.
  */
 Conference.prototype.sendSignal = function (signal) {
 

--- a/Conference.js
+++ b/Conference.js
@@ -2,14 +2,14 @@
  * Creates a Conference object with the given name and properties.
  * Note: this constructor is not a part of the public API (objects should be
  * created using Connection.createConference).
- * @param name name of the conference.
- * @param options Object with properties / settings related to the conference that will be created.
- * @param connection The Connection object for this Conference.
+ * @param options properties / settings related to the conference that will be created.
+ * @param options.name the name of the conference
+ * @param options.connection the Connection object for this Conference.
  * @constructor
  */
 
-function Conference(name, options, connection) {
-    
+function Conference(options) {
+  //assert that required options are provided, throw an error if not
 }
 
 /**

--- a/ConferenceEvents.js
+++ b/ConferenceEvents.js
@@ -62,7 +62,12 @@ var ConferenceEvents = {
     /**
      * Indicates that the connection to the conference has been restored.
      */
-    CONNECTION_RESTORED: "conference.connecionRestored"
+    CONNECTION_RESTORED: "conference.connecionRestored",
+
+    /**
+     * Indicates that a signal has been recieved
+     */
+    SIGNAL_RECEIVED: "conference.signalRecieved"
 };
 
 module.exports = ConferenceEvents;

--- a/Connection.js
+++ b/Connection.js
@@ -15,18 +15,17 @@ function Connection(appID, token, options) {
 
 /**
  * Connect the client with the server.
- * @param successCallback this callback will be called when the connection is successfull
- * @param errorCallback this callback will be called when the connection fail.
+ * @returns {Promise.<{void}, ConferenceError>} A promise that returns a ConferenceError if rejected.
  */
-Connection.prototype.connect = function (successCallback, errorCallback) {
+Connection.prototype.connect = function () {
 
 }
 
 /**
  * Disconnect the client from the server.
- * @param successCallback this callback will be called when we have successfully disconnected
+ * @returns {Promise.<{void}, ConferenceError>} A promise that returns a ConferenceError if rejected.
  */
-Connection.prototype.disconnect = function (successCallback) {
+Connection.prototype.disconnect = function () {
 
 }
 


### PR DESCRIPTION
The majority of these changes can be summed up as 
* prefer promise based api over callbacks
* consolidation of event binding, abstracting XMPP internals from core API (`signal` vs `presenceCommand`)
* Prefer options hash over "required items as params" constructor for forwards/backwards compat
* rename `createMediaStreams` as `share`